### PR TITLE
Fixed subscription to Flowable

### DIFF
--- a/Assignment-02/src/main/java/pcd/ass02/ex3/Launcher.java
+++ b/Assignment-02/src/main/java/pcd/ass02/ex3/Launcher.java
@@ -24,13 +24,14 @@ final class Launcher {
                 .subscribeOn(Schedulers.computation())
                 .map(toSearchResult(regex))
                 .blockingSubscribe(new SearchResultAccumulator() {
+                    private int fileWithOccurrencesCount;
+                    private long startTime;
+
                     @Override
                     public void onSubscribe(Subscription s) {
                         startTime = System.currentTimeMillis();
+                        s.request(Long.MAX_VALUE);
                     }
-
-                    private int fileWithOccurrencesCount;
-                    private long startTime;
 
                     @Override
                     public void onNext(SearchStatistics statistics) {

--- a/Assignment-02/src/main/java/pcd/ass02/ex3/SearchResultAccumulator.java
+++ b/Assignment-02/src/main/java/pcd/ass02/ex3/SearchResultAccumulator.java
@@ -2,6 +2,7 @@ package pcd.ass02.ex3;
 
 import io.reactivex.exceptions.OnErrorNotImplementedException;
 import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
 import pcd.ass02.domain.SearchResult;
 import pcd.ass02.domain.SearchStatistics;
 


### PR DESCRIPTION
When a subscriber gets subscribed to a flowable you need to provide the number of number of elements to requests to the upstream Publisher.

All of this is explained in the JavaDoc of the [Subscription](http://www.reactive-streams.org/reactive-streams-1.0.2-javadoc/org/reactivestreams/Subscription.html#request-long-) interface.